### PR TITLE
Set ``x_range`` as object attributes

### DIFF
--- a/dust_attenuation/averages.py
+++ b/dust_attenuation/averages.py
@@ -4,7 +4,7 @@ import numpy as np
 import astropy.units as u
 
 from .baseclasses import BaseAttAvModel
-from .helpers import _test_valid_x_range
+from .helpers import _test_valid_x_range, _positive_klambda
 
 __all__ = ["C00", "L02"]
 
@@ -118,7 +118,7 @@ class C00(BaseAttAvModel):
 
         axEbv[nir_indxs] = 2.659 * (-1.857 + 1.040 * 1 / x[nir_indxs]) + self.Rv
 
-        return np.maximum(axEbv, 0.)
+        return _positive_klambda(axEbv)
 
     def evaluate(self, x, Av):
         """
@@ -249,7 +249,7 @@ class L02(BaseAttAvModel):
 
         axEbv = 5.472 + (0.671 * 1 / x - 9.218 * 1e-3 / x ** 2 + 2.620 * 1e-3 / x ** 3)
 
-        return np.maximum(axEbv, 0.)
+        return _positive_klambda(axEbv)
 
     def evaluate(self, x, Av):
         """

--- a/dust_attenuation/averages.py
+++ b/dust_attenuation/averages.py
@@ -95,7 +95,7 @@ class C00(BaseAttAvModel):
         x = x_quant.value
 
         # check that the wavenumbers are within the defined range
-        _test_valid_x_range(x, x_range_C00, "C00")
+        _test_valid_x_range(x, self.x_range, "C00")
 
         # setup the ax vectors
         n_x = len(x)
@@ -103,7 +103,7 @@ class C00(BaseAttAvModel):
 
         # define the ranges
         uv2vis_indxs = np.where(np.logical_and(0.12 <= x, x < 0.63))
-        nir_indxs = np.where(np.logical_and(0.63 <= x, x < 2.2))
+        nir_indxs = np.where(np.logical_and(0.63 <= x, x < self.x_range[1]))
 
         axEbv[uv2vis_indxs] = (
             2.659
@@ -118,7 +118,7 @@ class C00(BaseAttAvModel):
 
         axEbv[nir_indxs] = 2.659 * (-1.857 + 1.040 * 1 / x[nir_indxs]) + self.Rv
 
-        return axEbv
+        return np.maximum(axEbv, 0.)
 
     def evaluate(self, x, Av):
         """
@@ -153,7 +153,7 @@ class C00(BaseAttAvModel):
         x = x_quant.value
 
         # check that the wavenumbers are within the defined range
-        _test_valid_x_range(x, x_range_C00, "C00")
+        _test_valid_x_range(x, self.x_range, "C00")
 
         ax = self.k_lambda(x) / self.Rv * Av
 
@@ -245,11 +245,11 @@ class L02(BaseAttAvModel):
         x = x_quant.value
 
         # check that the wavenumbers are within the defined range
-        _test_valid_x_range(x, x_range_L02, "L02")
+        _test_valid_x_range(x, self.x_range, "L02")
 
         axEbv = 5.472 + (0.671 * 1 / x - 9.218 * 1e-3 / x ** 2 + 2.620 * 1e-3 / x ** 3)
 
-        return axEbv
+        return np.maximum(axEbv, 0.)
 
     def evaluate(self, x, Av):
         """
@@ -284,7 +284,7 @@ class L02(BaseAttAvModel):
         x = x_quant.value
 
         # check that the wavenumbers are within the defined range
-        _test_valid_x_range(x, x_range_L02, "L02")
+        _test_valid_x_range(x, self.x_range, "L02")
 
         ax = self.k_lambda(x) / self.Rv * Av
 

--- a/dust_attenuation/helpers.py
+++ b/dust_attenuation/helpers.py
@@ -1,4 +1,6 @@
+import warnings
 import numpy as np
+from astropy.utils.exceptions import AstropyUserWarning
 
 
 def _test_valid_x_range(x, x_range, outname):
@@ -26,3 +28,25 @@ def _test_valid_x_range(x, x_range, outname):
             + str(x_range[1])
             + ", x has units micron]"
         )
+
+
+def _positive_klambda(klam):
+    """
+    Check that k-lambda arrays have no negative values
+    
+    Parameters
+    ----------
+    klam: float array
+        k-lambda array, which should only have positive values
+
+    Returns
+    -------
+    kout: float array
+        array clipped to zero if necessary
+    """
+    if not np.all(klam > 0):
+        warnings.warn('k-lambda has negative values, setting them to zero.',
+                       AstropyUserWarning)
+        return np.maximum(klam, 0.)
+    else:
+        return klam

--- a/dust_attenuation/helpers.py
+++ b/dust_attenuation/helpers.py
@@ -44,7 +44,7 @@ def _positive_klambda(klam):
     kout: float array
         array clipped to zero if necessary
     """
-    if not np.all(klam > 0):
+    if not np.all(klam >= 0):
         warnings.warn('k-lambda has negative values, setting them to zero.',
                        AstropyUserWarning)
         return np.maximum(klam, 0.)

--- a/dust_attenuation/radiative_transfer.py
+++ b/dust_attenuation/radiative_transfer.py
@@ -295,7 +295,7 @@ class WG00(BaseAtttauVModel):
         x = x_quant.value
 
         # check that the wavenumbers are within the defined range
-        _test_valid_x_range(x, x_range_WG00, "WG00")
+        _test_valid_x_range(x, self.x_range, "WG00")
 
         # setup the ax vectors
         n_x = len(x)
@@ -346,7 +346,7 @@ class WG00(BaseAtttauVModel):
         x = x_quant.value
 
         # check that the wavenumbers are within the defined range
-        _test_valid_x_range(x, x_range_WG00, "WG00")
+        _test_valid_x_range(x, self.x_range, "WG00")
 
         # setup the ax vectors
         x = np.atleast_1d(x)
@@ -393,7 +393,7 @@ class WG00(BaseAtttauVModel):
         x = x_quant.value
 
         # check that the wavenumbers are within the defined range
-        _test_valid_x_range(x, x_range_WG00, "WG00")
+        _test_valid_x_range(x, self.x_range, "WG00")
 
         # setup the ax vectors
         x = np.atleast_1d(x)
@@ -440,7 +440,7 @@ class WG00(BaseAtttauVModel):
         x = x_quant.value
 
         # check that the wavenumbers are within the defined range
-        _test_valid_x_range(x, x_range_WG00, "WG00")
+        _test_valid_x_range(x, self.x_range, "WG00")
 
         # setup the ax vectors
         x = np.atleast_1d(x)
@@ -487,7 +487,7 @@ class WG00(BaseAtttauVModel):
         x = x_quant.value
 
         # check that the wavenumbers are within the defined range
-        _test_valid_x_range(x, x_range_WG00, "WG00")
+        _test_valid_x_range(x, self.x_range, "WG00")
 
         # setup the ax vectors
         x = np.atleast_1d(x)
@@ -532,7 +532,7 @@ class WG00(BaseAtttauVModel):
         x = x_quant.value
 
         # check that the wavenumbers are within the defined range
-        _test_valid_x_range(x, x_range_WG00, "WG00")
+        _test_valid_x_range(x, self.x_range, "WG00")
 
         # setup the ax vectors
         x = np.atleast_1d(x)
@@ -650,7 +650,7 @@ class WG00(BaseAtttauVModel):
         x = x_quant.value
 
         # check that the wavenumbers are within the defined range
-        _test_valid_x_range(x, x_range_WG00, "WG00")
+        _test_valid_x_range(x, self.x_range, "WG00")
 
         # setup the ax vectors
         x = np.atleast_1d(x)

--- a/dust_attenuation/shapes.py
+++ b/dust_attenuation/shapes.py
@@ -302,7 +302,7 @@ class N09(BaseAttAvModel):
         # Use recipe of Leitherer 2002 below 0.15 microns
         mask_L02 = x <= 0.15
         mask_L02 &= x >= L02.x_range[0]
-        
+
         axEbv[mask_L02] = L02().k_lambda(x[mask_L02])
 
         # Add the UV bump using the Drude profile
@@ -421,10 +421,9 @@ class SBL18(N09):
         plt.title("SBL18 with varying slopes")
         plt.show()
     """
-    
+
     x_range = x_range_SBL18
-    
-    
+
     def k_lambda(self, x, x0, gamma, ampl, slope):
         """ Compute the starburst reddening curve k'(λ)=A(λ)/E(B-V)
         using recipe of Calzetti 2000 and Leitherer 2002

--- a/dust_attenuation/shapes.py
+++ b/dust_attenuation/shapes.py
@@ -301,7 +301,7 @@ class N09(BaseAttAvModel):
 
         # Use recipe of Leitherer 2002 below 0.15 microns
         mask_L02 = x <= 0.15
-        mask_L02 &= x > L02.x_range[0]
+        mask_L02 &= x >= L02.x_range[0]
         
         axEbv[mask_L02] = L02().k_lambda(x[mask_L02])
 

--- a/dust_attenuation/shapes.py
+++ b/dust_attenuation/shapes.py
@@ -290,7 +290,7 @@ class N09(BaseAttAvModel):
         x = x_quant.value
 
         # check that the wavenumbers are within the defined range
-        _test_valid_x_range(x, x_range_N09, "N09")
+        _test_valid_x_range(x, self.x_range, "N09")
 
         # setup the axEbv vectors
         axEbv = np.zeros(len(x))
@@ -301,6 +301,8 @@ class N09(BaseAttAvModel):
 
         # Use recipe of Leitherer 2002 below 0.15 microns
         mask_L02 = x <= 0.15
+        mask_L02 &= x > L02.x_range[0]
+        
         axEbv[mask_L02] = L02().k_lambda(x[mask_L02])
 
         # Add the UV bump using the Drude profile
@@ -309,7 +311,7 @@ class N09(BaseAttAvModel):
         # Multiply the reddening curve with a power law with varying slope
         axEbv *= self.power_law(x, slope)
 
-        return axEbv
+        return np.maximum(axEbv, 0.)
 
     def evaluate(self, x, Av, x0, gamma, ampl, slope):
         """
@@ -419,7 +421,10 @@ class SBL18(N09):
         plt.title("SBL18 with varying slopes")
         plt.show()
     """
-
+    
+    x_range = x_range_SBL18
+    
+    
     def k_lambda(self, x, x0, gamma, ampl, slope):
         """ Compute the starburst reddening curve k'(λ)=A(λ)/E(B-V)
         using recipe of Calzetti 2000 and Leitherer 2002
@@ -464,7 +469,7 @@ class SBL18(N09):
         x = x_quant.value
 
         # check that the wavenumbers are within the defined range
-        _test_valid_x_range(x, x_range_SBL18, "SBL18")
+        _test_valid_x_range(x, self.x_range, "SBL18")
 
         # setup the axEbv vectors
         axEbv = np.zeros(len(x))
@@ -483,4 +488,4 @@ class SBL18(N09):
         # Add the UV bump using the Drude profile
         axEbv += self.uv_bump(x, x0, gamma, ampl)
 
-        return axEbv
+        return np.maximum(axEbv, 0.)

--- a/dust_attenuation/shapes.py
+++ b/dust_attenuation/shapes.py
@@ -4,7 +4,7 @@ import numpy as np
 import astropy.units as u
 
 from .baseclasses import BaseAttAvModel
-from .helpers import _test_valid_x_range
+from .helpers import _test_valid_x_range, _positive_klambda
 
 from .averages import C00, L02
 from astropy.modeling import Parameter, InputParameterError
@@ -311,7 +311,7 @@ class N09(BaseAttAvModel):
         # Multiply the reddening curve with a power law with varying slope
         axEbv *= self.power_law(x, slope)
 
-        return np.maximum(axEbv, 0.)
+        return _positive_klambda(axEbv)
 
     def evaluate(self, x, Av, x0, gamma, ampl, slope):
         """
@@ -487,4 +487,4 @@ class SBL18(N09):
         # Add the UV bump using the Drude profile
         axEbv += self.uv_bump(x, x0, gamma, ampl)
 
-        return np.maximum(axEbv, 0.)
+        return _positive_klambda(axEbv)


### PR DESCRIPTION
This PR sets the  checks on the ``x_range`` limits to the object attributes rather than global variables of the module code.  This is useful, e.g., if one would like to modify those values and enable extrapolation beyond the limits without raising errors (however ill advised that may be), and also generally seems to be how the objects are implemented in the companion `dust_extinction` module.

The changes also force positive ``k_lambda`` values.
